### PR TITLE
bayesian.py, wf_func.py: 使用 MCMC 的采样估算 mu。

### DIFF
--- a/wf_func.py
+++ b/wf_func.py
@@ -363,7 +363,11 @@ def metropolis_fbmp(y, A, sig2w, sig2s, mus, p1, cha, mu_t, prior=False, space=T
         c_star[k, t] = c
     nu_star = np.cumsum(Δν_history[0][steps]) + nu_root + Δν_history[1]
 
-    return xmmse_star[burn:, :], nu_star[burn:], T_list[burn:], c_star[burn:, :], flip[burn:], num - burn
+    flip[np.abs(flip) == 2] = 0 # 平移不改变 PE 数
+    NPE0 = int(mu_t + 0.5)
+    NPE_evo = np.cumsum(np.insert(flip, 0, NPE0))[burn:]
+
+    return xmmse_star[burn:, :], nu_star[burn:], T_list[burn:], c_star[burn:, :], NPE_evo, num - burn
 
 def nu_direct(y, A, nx, mus, sig2s, sig2w, la, prior=True, space=True):
     M, N = A.shape


### PR DESCRIPTION
设 {s_i} 是一系列 PE 位置配置的采样。 s_i = {t_1, t_2, ..., t_{N_i}}
为 N_i 个 PE。那么 mu 的 likelihood 的 MCMC 统计量为

  L(mu) = C * \sum_i e^{-mu} (mu/mu_0)^N_i

其中 C 是与 mu 无关的常数。进而 mu 的统计量为

  \hat{mu} = argmax_mu log L(mu)

这其中不能使用 nu_star，因为 nu_star 的大小已经反应在 {s_i} 元素出现
的频数中，不能重复使用。